### PR TITLE
Fixed PHP version requirement (7.1 -> 7.2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "symfony/framework-bundle": "^5.1 || ^6.0",
     "irazasyed/telegram-bot-sdk": "^3.4"
   },


### PR DESCRIPTION
Fixed PHP version requirement (7.1 -> 7.2) because "irazasyed/telegram-bot-sdk: ^3.4" require minimal PHP version ^7.2. Installation on PHP version 7.1 failed.